### PR TITLE
add: 정렬 기준 추가

### DIFF
--- a/Services/studyService.js
+++ b/Services/studyService.js
@@ -27,16 +27,16 @@ export const getStudies = asyncHandler(async (req, res) => {
   let orderByClause;
   switch (orderBy) {
     case 'recent':
-      orderByClause = { createdAt: 'desc' };
+      orderByClause = [{ createdAt: 'desc' }, { id: 'desc' }];
       break;
     case 'old':
-      orderByClause = { createdAt: 'asc' };
+      orderByClause = [{ createdAt: 'asc' }, { id: 'asc' }];
       break;
     case 'highestPoints':
-      orderByClause = [{ point: 'desc' }, { createdAt: 'desc' }];
+      orderByClause = [{ point: 'desc' }, { createdAt: 'asc' }, { id: 'asc' }];
       break;
     case 'lowestPoints':
-      orderByClause = [{ point: 'asc' }, { createdAt: 'desc' }];
+      orderByClause = [{ point: 'asc' }, { createdAt: 'desc' }, { id: 'desc' }];
       break;
   }
 

--- a/Services/studyService.js
+++ b/Services/studyService.js
@@ -27,7 +27,7 @@ export const getStudies = asyncHandler(async (req, res) => {
   let orderByClause;
   switch (orderBy) {
     case 'recent':
-      orderByClause = [{ createdAt: 'desc' }, { id: 'desc' }];
+      orderByClause = [{ createdAt: 'desc' }, { id: 'asc' }];
       break;
     case 'old':
       orderByClause = [{ createdAt: 'asc' }, { id: 'asc' }];
@@ -36,7 +36,7 @@ export const getStudies = asyncHandler(async (req, res) => {
       orderByClause = [{ point: 'desc' }, { createdAt: 'asc' }, { id: 'asc' }];
       break;
     case 'lowestPoints':
-      orderByClause = [{ point: 'asc' }, { createdAt: 'desc' }, { id: 'desc' }];
+      orderByClause = [{ point: 'asc' }, { createdAt: 'desc' }, { id: 'asc' }];
       break;
   }
 


### PR DESCRIPTION
## 변경사항
- 최신순, 오래된 순에 정렬기준 id 추가
- 포인트 많은 순, 적은 순에 정렬기준 id 추가

최신순: 생성한 날짜를 내림차순, 아이디를 오름차순 => 최신 것부터
오래된 순: 생성한 날짜를 오름차순, 아이디를 오름차순 => 오래된 것부터
포인트 많은 순: 포인트가 많은 순, 생성한 날짜를 오름차순, 아이디를 오름차순 => 같은 포인트라면 오래된 것부터 보이게끔
포인트가 적은 순: 포인트가 적은 순서, 생성한 날짜를 내림차순, 아이디를 오름차순 => 같은 포인트라면 최신 것부터 보이게끔

## 사유
- 중복된 데이터가 발생하지 않기 위해 추가